### PR TITLE
Fixed bugs in Filter

### DIFF
--- a/sedfitter/filter/filter.py
+++ b/sedfitter/filter/filter.py
@@ -81,7 +81,7 @@ class Filter(object):
             raise ValueError("nu has not been set")
         if self.response is None:
             raise ValueError("response has not been set")
-        self.response /= integrate(self.nu.to(u.Hz).value, self.response)
+        self.response = self.response / np.abs(integrate(self.nu.to(u.Hz).value, self.response))
 
     def rebin(self, nu_new):
         """

--- a/sedfitter/filter/tests/test_filter.py
+++ b/sedfitter/filter/tests/test_filter.py
@@ -52,3 +52,27 @@ def test_read(filename):
         assert len(f.nu) == 391
     else:
         assert len(f.nu) == 21
+        
+        
+def test_norm():
+    f = Filter()
+    f.nu = [1.,2.,3.] * u.Hz
+    f.response = [1.,2.,1.]
+    f.normalize()
+    np.testing.assert_allclose(f.response,[1/3., 2./3., 1./3.])
+
+    
+def test_norm_int():
+    f = Filter()
+    f.nu = [1,2,3] * u.Hz
+    f.response = [1,2,1]
+    f.normalize()
+    np.testing.assert_allclose(f.response,[1/3., 2./3., 1./3.])
+    
+    
+def test_norm_inverted():
+    f = Filter()
+    f.nu = [3.,2.,1.] * u.Hz
+    f.response = [1.,2.,1.]
+    f.normalize()
+    np.testing.assert_allclose(f.response,[1/3., 2./3., 1./3.])


### PR DESCRIPTION
Normalization would make filter negative if order of frequencies was inverted, and integer values for the response would cause issues.