### PR TITLE
Use memmap when reading in model grids

### DIFF
--- a/sedfitter/fit.py
+++ b/sedfitter/fit.py
@@ -60,7 +60,7 @@ class Fitter(object):
 
     def __init__(self, filter_names, apertures, model_dir,
                  extinction_law=None, av_range=None, distance_range=None,
-                 remove_resolved=False):
+                 remove_resolved=False, use_memmap=True):
 
         validate_array('apertures', apertures, domain='positive', ndim=1, physical_type='angle')
         validate_array('distance_range', distance_range, domain='positive', ndim=1, shape=(2,), physical_type='length')
@@ -82,7 +82,10 @@ class Fitter(object):
             self.filters.append(filt)
 
         # Read in models
-        self.models = Models.read(model_dir, self.filters, distance_range=distance_range, remove_resolved=remove_resolved)
+        self.models = Models.read(model_dir, self.filters,
+                                  distance_range=distance_range,
+                                  remove_resolved=remove_resolved,
+                                  use_memmap=use_memmap)
 
         # Add wavelength to filters
         for i, f in enumerate(self.filters):

--- a/sedfitter/models.py
+++ b/sedfitter/models.py
@@ -172,7 +172,7 @@ class Models(object):
                     n_distances = 1
                     m.distances = np.array([distance_range_kpc[0]]) * u.kpc
                 else:
-                    n_distances = int(1 + (np.log10(distance_range_kpc[1]) - np.log10(distance_range_kpc[0])) / modpar['logd_step'])
+                    n_distances = int(np.ceil(1 + (np.log10(distance_range_kpc[1]) - np.log10(distance_range_kpc[0])) / modpar['logd_step']))
                     m.distances = np.logspace(np.log10(distance_range_kpc[0]), np.log10(distance_range_kpc[1]), n_distances) * u.kpc
                 print("   Number of distances :  %i" % m.n_distances)
             else:
@@ -257,7 +257,7 @@ class Models(object):
                     n_distances = 1
                     m.distances = np.array([distance_range_kpc[0]]) * u.kpc
                 else:
-                    n_distances = int(1 + (np.log10(distance_range_kpc[1]) - np.log10(distance_range_kpc[0])) / modpar['logd_step'])
+                    n_distances = int(np.ceil(1 + (np.log10(distance_range_kpc[1]) - np.log10(distance_range_kpc[0])) / modpar['logd_step']))
                     m.distances = np.logspace(np.log10(distance_range_kpc[0]), np.log10(distance_range_kpc[1]), n_distances) * u.kpc
                 print("   Number of distances :  %i" % m.n_distances)
             else:


### PR DESCRIPTION
This PR allows the use of memory maps (`mmap`s) when reading in flux grids.  This can help read in grids when a large number of wavelengths or distances are being probed and the computer's RAM is limited.